### PR TITLE
Add menu command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This project is a Telegram bot that uses a Large Language Model (LLM) agent to h
     - `/disconnect_calendar`: Remove Google Calendar integration.
     - `/my_status`: Check the current connection status.
     - `/set_timezone`: Configure your local timezone.
+    - `/menu`: Show a button-based menu of commands.
     - `/help`: Get assistance and a list of commands.
 
 ## Setup and Installation
@@ -169,6 +170,7 @@ Once the bot is running and you've started a chat with it on Telegram:
     - `/disconnect_calendar`: Revokes the bot's access to your Google Calendar and deletes your stored credentials.
     - `/my_status`: Checks if your Google Calendar is currently connected and if the credentials are valid.
     - `/set_timezone`: Allows you to set or update your local timezone.
+    - `/menu`: Displays a button-based menu of commands.
     - `/summary [time period]`: Explicitly asks for a summary of events for a given period (e.g., `/summary today`, `/summary next week`).
 
 ## Project Structure

--- a/bot.py
+++ b/bot.py
@@ -92,6 +92,7 @@ def main() -> None:
     # Commands
     application.add_handler(CommandHandler("start", handlers.start))
     application.add_handler(CommandHandler("help", handlers.help_command))
+    application.add_handler(CommandHandler("menu", handlers.menu_command))
     application.add_handler(CommandHandler("connect_calendar", handlers.connect_calendar))
     application.add_handler(CommandHandler("my_status", handlers.my_status))
     application.add_handler(CommandHandler("disconnect_calendar", handlers.disconnect_calendar))

--- a/handlers.py
+++ b/handlers.py
@@ -383,6 +383,26 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     await update.message.reply_text(help_text, parse_mode=ParseMode.MARKDOWN)
 
 
+async def menu_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Displays a reply keyboard with available commands."""
+    assert update.message is not None, "Update message should not be None"
+    keyboard = [
+        ["/connect_calendar", "/my_status"],
+        ["/set_timezone", "/disconnect_calendar"],
+        ["/summary", "/glist_add"],
+        ["/glist_show", "/glist_clear"],
+        ["/request_access", "/help"],
+    ]
+    try:
+        reply_markup = ReplyKeyboardMarkup(
+            keyboard, resize_keyboard=True, one_time_keyboard=True
+        )
+    except TypeError:
+        reply_markup = ReplyKeyboardMarkup()
+        reply_markup.keyboard = keyboard
+    await update.message.reply_text("Choose a command:", reply_markup=reply_markup)
+
+
 async def request_calendar_access_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """
     Handles the /request_access command.

--- a/tests/test_grocery_integration.py
+++ b/tests/test_grocery_integration.py
@@ -1,0 +1,194 @@
+import sys
+import types
+import importlib
+import asyncio
+
+import pytest
+
+# ---- Fake Firestore Implementation ----
+
+class FakeArrayUnion:
+    def __init__(self, items):
+        self.items = list(items)
+
+class FakeSnapshot:
+    def __init__(self, data):
+        self._data = data
+    @property
+    def exists(self):
+        return self._data is not None
+    def to_dict(self):
+        return self._data
+
+class FakeDocument:
+    def __init__(self, collection, doc_id):
+        self.collection = collection
+        self.doc_id = doc_id
+    def get(self):
+        data = self.collection.store.get(self.doc_id)
+        return FakeSnapshot(data)
+    def set(self, data, merge=False):
+        existing = self.collection.store.get(self.doc_id, {}) if merge else {}
+        for key, value in data.items():
+            if isinstance(value, FakeArrayUnion):
+                items = existing.get(key, [])
+                for item in value.items:
+                    if item not in items:
+                        items.append(item)
+                existing[key] = items
+            else:
+                existing[key] = value
+        self.collection.store[self.doc_id] = existing
+    def delete(self):
+        self.collection.store.pop(self.doc_id, None)
+
+class FakeCollection:
+    def __init__(self):
+        self.store = {}
+    def document(self, doc_id):
+        return FakeDocument(self, doc_id)
+
+# ---- Pytest Fixture ----
+
+@pytest.fixture
+def gs_module(monkeypatch):
+    # stub config before importing google_services
+    config_mod = types.ModuleType("config")
+    config_mod.FIRESTORE_DB = None
+    config_mod.FS_COLLECTION_GROCERY_LISTS = "grocery"
+    config_mod.FS_COLLECTION_PREFS = "prefs"
+    config_mod.FS_COLLECTION_PENDING_EVENTS = "pe"
+    config_mod.FS_COLLECTION_PENDING_DELETIONS = "pd"
+    config_mod.FS_COLLECTION_CALENDAR_ACCESS_REQUESTS = "car"
+    config_mod.FS_COLLECTION_LC_CHAT_HISTORIES = "lc"
+    config_mod.FS_COLLECTION_GENERAL_CHAT_HISTORIES = "gc"
+    config_mod.GOOGLE_CALENDAR_SCOPES = []
+    config_mod.OAUTH_REDIRECT_URI = "http://localhost"
+    monkeypatch.setitem(sys.modules, "config", config_mod)
+
+    # dummy pytz module
+    pytz_mod = types.ModuleType("pytz")
+    class UnknownTimeZoneError(Exception):
+        pass
+    pytz_mod.UnknownTimeZoneError = UnknownTimeZoneError
+    pytz_mod.timezone = lambda name: name
+    pytz_mod.utc = "UTC"
+    monkeypatch.setitem(sys.modules, "pytz", pytz_mod)
+    monkeypatch.setitem(sys.modules, "pytz.exceptions", types.SimpleNamespace(UnknownTimeZoneError=UnknownTimeZoneError))
+
+    # minimal dateutil module
+    dateutil_mod = types.ModuleType("dateutil")
+    parser_mod = types.ModuleType("dateutil.parser")
+    parser_mod.isoparse = lambda s: s
+    monkeypatch.setitem(sys.modules, "dateutil", dateutil_mod)
+    monkeypatch.setitem(sys.modules, "dateutil.parser", parser_mod)
+
+    # minimal pydantic module
+    pydantic_mod = types.ModuleType("pydantic")
+    class BaseModel:
+        pass
+    pydantic_mod.BaseModel = BaseModel
+    monkeypatch.setitem(sys.modules, "pydantic", pydantic_mod)
+
+    # stub google packages used during import
+    google_pkg = types.ModuleType("google")
+    monkeypatch.setitem(sys.modules, "google", google_pkg)
+    google_pkg.cloud = types.ModuleType("google.cloud")
+    monkeypatch.setitem(sys.modules, "google.cloud", google_pkg.cloud)
+    firestore_mod = types.ModuleType("google.cloud.firestore")
+    firestore_mod.ArrayUnion = FakeArrayUnion
+    firestore_mod.SERVER_TIMESTAMP = object()
+    def transactional(func):
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+        return wrapper
+    firestore_mod.transactional = transactional
+    monkeypatch.setitem(sys.modules, "google.cloud.firestore", firestore_mod)
+    google_pkg.cloud.firestore = firestore_mod
+    firestore_v1_mod = types.ModuleType("google.cloud.firestore_v1")
+    base_query_mod = types.ModuleType("google.cloud.firestore_v1.base_query")
+    base_query_mod.FieldFilter = object
+    monkeypatch.setitem(sys.modules, "google.cloud.firestore_v1", firestore_v1_mod)
+    monkeypatch.setitem(sys.modules, "google.cloud.firestore_v1.base_query", base_query_mod)
+    secret_mod = types.ModuleType("google.cloud.secretmanager")
+    monkeypatch.setitem(sys.modules, "google.cloud.secretmanager", secret_mod)
+
+    google_pkg.oauth2 = types.ModuleType("google.oauth2")
+    cred_mod = types.ModuleType("google.oauth2.credentials")
+    cred_mod.Credentials = object
+    monkeypatch.setitem(sys.modules, "google.oauth2", google_pkg.oauth2)
+    monkeypatch.setitem(sys.modules, "google.oauth2.credentials", cred_mod)
+
+    google_auth_mod = types.ModuleType("google_auth_oauthlib")
+    flow_mod = types.ModuleType("google_auth_oauthlib.flow")
+    flow_mod.Flow = object
+    monkeypatch.setitem(sys.modules, "google_auth_oauthlib", google_auth_mod)
+    monkeypatch.setitem(sys.modules, "google_auth_oauthlib.flow", flow_mod)
+
+    google_pkg.auth = types.ModuleType("google.auth")
+    google_pkg.auth.transport = types.ModuleType("google.auth.transport")
+    requests_mod = types.ModuleType("google.auth.transport.requests")
+    requests_mod.Request = object
+    monkeypatch.setitem(sys.modules, "google.auth", google_pkg.auth)
+    monkeypatch.setitem(sys.modules, "google.auth.transport", google_pkg.auth.transport)
+    monkeypatch.setitem(sys.modules, "google.auth.transport.requests", requests_mod)
+
+    googleapiclient_mod = types.ModuleType("googleapiclient")
+    discovery_mod = types.ModuleType("googleapiclient.discovery")
+    discovery_mod.build = lambda *a, **kw: None
+    errors_mod = types.ModuleType("googleapiclient.errors")
+    class HttpError(Exception):
+        def __init__(self, resp=None, content=b""):
+            self.resp = types.SimpleNamespace(status=500, reason="error")
+            self.content = content
+    errors_mod.HttpError = HttpError
+    monkeypatch.setitem(sys.modules, "googleapiclient", googleapiclient_mod)
+    monkeypatch.setitem(sys.modules, "googleapiclient.discovery", discovery_mod)
+    monkeypatch.setitem(sys.modules, "googleapiclient.errors", errors_mod)
+
+    api_core_mod = types.ModuleType("google.api_core")
+    exceptions_mod = types.ModuleType("google.api_core.exceptions")
+    class NotFound(Exception):
+        pass
+    exceptions_mod.NotFound = NotFound
+    monkeypatch.setitem(sys.modules, "google.api_core", api_core_mod)
+    monkeypatch.setitem(sys.modules, "google.api_core.exceptions", exceptions_mod)
+
+    # ensure clean import
+    if "google_services" in sys.modules:
+        del sys.modules["google_services"]
+    gs = importlib.import_module("google_services")
+
+    # replace the Firestore collection with our fake implementation
+    fake_collection = FakeCollection()
+    monkeypatch.setattr(gs, "FS_COLLECTION_GROCERY_LISTS", fake_collection)
+    monkeypatch.setattr(gs, "firestore", types.SimpleNamespace(ArrayUnion=FakeArrayUnion))
+    return gs
+
+# ---- Tests ----
+
+def test_grocery_list_flow(gs_module):
+    gs = gs_module
+    user_id = 42
+
+    # initially empty
+    result = asyncio.run(gs.get_grocery_list(user_id))
+    assert result == []
+
+    # add items
+    success = asyncio.run(gs.add_to_grocery_list(user_id, ["apples", "bananas"]))
+    assert success
+    result = asyncio.run(gs.get_grocery_list(user_id))
+    assert sorted(result) == ["apples", "bananas"]
+
+    # add duplicate and new item
+    success = asyncio.run(gs.add_to_grocery_list(user_id, ["bananas", "carrots"]))
+    assert success
+    result = asyncio.run(gs.get_grocery_list(user_id))
+    assert sorted(result) == ["apples", "bananas", "carrots"]
+
+    # delete list
+    success = asyncio.run(gs.delete_grocery_list(user_id))
+    assert success
+    result = asyncio.run(gs.get_grocery_list(user_id))
+    assert result == []

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -190,3 +190,17 @@ def test_start_sends_welcome_message(handlers_module):
     asyncio.run(handlers_module.start(mock_update, mock_context))
 
     mock_message.reply_html.assert_called_once()
+
+
+def test_menu_command_shows_keyboard(handlers_module):
+    mock_update = MagicMock()
+    mock_message = MagicMock()
+    mock_message.reply_text = AsyncMock()
+    mock_update.message = mock_message
+    mock_update.effective_user = MagicMock()
+
+    mock_context = MagicMock()
+
+    asyncio.run(handlers_module.menu_command(mock_update, mock_context))
+
+    mock_message.reply_text.assert_called_once()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,227 @@
+import sys
+import types
+import importlib
+import zoneinfo
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+class DummyPytzModule(types.ModuleType):
+    class UnknownTimeZoneError(Exception):
+        pass
+
+    class BaseTzInfo(zoneinfo.ZoneInfo):
+        pass
+
+    def timezone(self, name: str):
+        try:
+            return zoneinfo.ZoneInfo(name)
+        except Exception:
+            raise self.UnknownTimeZoneError
+
+    utc = zoneinfo.ZoneInfo("UTC")
+
+
+@pytest.fixture
+def tools(monkeypatch):
+    dummy = DummyPytzModule("pytz")
+    monkeypatch.setitem(sys.modules, "pytz", dummy)
+    exc_mod = types.ModuleType("pytz.exceptions")
+    exc_mod.UnknownTimeZoneError = dummy.UnknownTimeZoneError
+    monkeypatch.setitem(sys.modules, "pytz.exceptions", exc_mod)
+
+    parser_mod = types.ModuleType("dateutil.parser")
+    def isoparse(s: str):
+        from datetime import datetime
+        if s.endswith("Z"):
+            s = s[:-1] + "+00:00"
+        return datetime.fromisoformat(s)
+    parser_mod.isoparse = isoparse
+    relativedelta_mod = types.ModuleType("dateutil.relativedelta")
+    class relativedelta:
+        def __init__(self, *args, **kwargs):
+            self.years = kwargs.get("years", 0)
+            self.months = kwargs.get("months", 0)
+            self.days = kwargs.get("days", 0)
+            self.hours = kwargs.get("hours", 0)
+            self.minutes = kwargs.get("minutes", 0)
+    relativedelta_mod.relativedelta = relativedelta
+    dateutil_pkg = types.ModuleType("dateutil")
+    dateutil_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "dateutil", dateutil_pkg)
+    monkeypatch.setitem(sys.modules, "dateutil.parser", parser_mod)
+    monkeypatch.setitem(sys.modules, "dateutil.relativedelta", relativedelta_mod)
+
+    pydantic_mod = types.ModuleType("pydantic")
+    class BaseModel:
+        pass
+    def Field(**kwargs):
+        return None
+    pydantic_mod.BaseModel = BaseModel
+    pydantic_mod.Field = Field
+    monkeypatch.setitem(sys.modules, "pydantic", pydantic_mod)
+
+    langchain_tools = types.ModuleType("langchain.tools")
+    class BaseTool:
+        def __init__(self, *a, **k):
+            for key, val in k.items():
+                setattr(self, key, val)
+    langchain_tools.BaseTool = BaseTool
+    monkeypatch.setitem(sys.modules, "langchain.tools", langchain_tools)
+    langchain_core_tools = types.ModuleType("langchain_core.tools")
+    langchain_core_tools.BaseTool = BaseTool
+    monkeypatch.setitem(sys.modules, "langchain_core.tools", langchain_core_tools)
+
+    dotenv_mod = types.ModuleType("dotenv")
+    dotenv_mod.load_dotenv = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "dotenv", dotenv_mod)
+
+    config_mod = types.ModuleType("config")
+    config_mod.TELEGRAM_BOT_TOKEN = ""
+    config_mod.GOOGLE_CLIENT_SECRETS_FILE = ""
+    config_mod.GOOGLE_API_KEY = ""
+    config_mod.OAUTH_REDIRECT_URI = ""
+    monkeypatch.setitem(sys.modules, "config", config_mod)
+
+    gs_mod = types.ModuleType("google_services")
+    from unittest.mock import MagicMock
+    gs_mod.add_to_grocery_list = lambda *a, **k: True
+    gs_mod.delete_grocery_list = lambda *a, **k: True
+    gs_mod.get_grocery_list = MagicMock(return_value=["milk"])
+    gs_mod.add_pending_event = AsyncMock(return_value=True)
+    gs_mod.delete_pending_deletion = lambda *a, **k: None
+    gs_mod.get_calendar_event_by_id = AsyncMock(return_value={
+        "summary": "Event",
+        "start": {"dateTime": "2024-01-01T00:00:00+00:00"},
+        "end": {"dateTime": "2024-01-01T01:00:00+00:00"},
+        "id": "1",
+    })
+    gs_mod.add_pending_deletion = lambda *a, **k: True
+    gs_mod.delete_pending_event = lambda *a, **k: None
+    gs_mod.get_calendar_events = AsyncMock(return_value=[{"id": "ev1"}])
+    gs_mod.search_calendar_events = AsyncMock(return_value=[{"id": "ev2"}])
+    sys.modules["google_services"] = gs_mod
+
+    llm_service_mod = types.ModuleType("llm.llm_service")
+    llm_service_mod.extract_create_args_llm = AsyncMock(return_value={
+        "summary": "Event",
+        "start": {"dateTime": "2024-01-01T00:00:00+00:00"},
+        "end": {"dateTime": "2024-01-01T01:00:00+00:00"},
+        "description": "desc",
+        "location": "loc",
+    })
+    llm_service_mod.extract_read_args_llm = AsyncMock(return_value={
+        "start_iso": "2024-01-01T00:00:00+00:00",
+        "end_iso": "2024-01-02T00:00:00+00:00",
+    })
+    llm_service_mod.extract_search_args_llm = AsyncMock(return_value={
+        "query": "meet",
+        "start_iso": "2024-01-01T00:00:00+00:00",
+        "end_iso": "2024-01-02T00:00:00+00:00",
+    })
+    if "llm" in sys.modules:
+        del sys.modules["llm"]
+    import importlib
+    llm_pkg = importlib.import_module("llm")
+    monkeypatch.setattr(llm_pkg, "llm_service", llm_service_mod, raising=False)
+    sys.modules["llm.llm_service"] = llm_service_mod
+
+    utils_mod = types.ModuleType("utils")
+    utils_mod._format_event_time = lambda *a, **k: "formatted time"
+    sys.modules["utils"] = utils_mod
+
+    fmt_mod = importlib.import_module("llm.tools.formatting")
+    monkeypatch.setattr(fmt_mod, "format_event_list_for_agent", lambda *a, **k: "formatted events")
+
+    modules = {}
+    names = [
+        "add_grocery_item_tool",
+        "clear_grocery_list_tool",
+        "show_grocery_list_tool",
+        "get_current_time_tool",
+        "create_calendar",
+        "delete_calendar",
+        "read_calendar",
+        "search_calendar",
+    ]
+    for name in names:
+        mod = importlib.import_module(f"llm.tools.{name}")
+        importlib.reload(mod)
+        modules[name] = mod
+    return modules
+
+def test_add_grocery_item_success(tools):
+    tool_cls = tools["add_grocery_item_tool"].AddGroceryItemTool
+    tool = tool_cls(user_id=1, user_timezone_str="UTC")
+    result = tool._run("eggs, bread")
+    assert "Successfully added" in result
+
+
+def test_add_grocery_item_invalid(tools):
+    tool_cls = tools["add_grocery_item_tool"].AddGroceryItemTool
+    tool = tool_cls(user_id=1, user_timezone_str="UTC")
+    result = tool._run("")
+    assert result.startswith("Input error")
+
+
+def test_clear_grocery_list(tools):
+    tool_cls = tools["clear_grocery_list_tool"].ClearGroceryListTool
+    tool = tool_cls(user_id=1, user_timezone_str="UTC")
+    result = tool._run()
+    assert result.startswith("Successfully cleared")
+
+
+def test_show_grocery_list(tools):
+    tool_cls = tools["show_grocery_list_tool"].ShowGroceryListTool
+    tool = tool_cls(user_id=1, user_timezone_str="UTC")
+    result = tool._run()
+    assert result.startswith("Your grocery list")
+
+
+def test_show_grocery_list_empty(tools, monkeypatch):
+    gs = sys.modules["google_services"]
+    gs.get_grocery_list.return_value = []
+    tool_cls = tools["show_grocery_list_tool"].ShowGroceryListTool
+    tool = tool_cls(user_id=1, user_timezone_str="UTC")
+    result = tool._run()
+    assert "currently empty" in result
+
+
+def test_get_current_time(tools, monkeypatch):
+    tool_cls = tools["get_current_time_tool"].GetCurrentTimeTool
+    tool = tool_cls(user_id=1, user_timezone_str="UTC")
+    from datetime import datetime
+    fixed = datetime(2024, 1, 1, 12, 0, tzinfo=zoneinfo.ZoneInfo("UTC"))
+    monkeypatch.setattr(tools["get_current_time_tool"], "datetime", types.SimpleNamespace(now=lambda tz=None: fixed))
+    result = asyncio.run(tool._arun())
+    assert "2024-01-01" in result
+    assert "ISO: 2024-01-01T12:00:00+00:00" in result
+
+
+def test_create_calendar_event(tools):
+    tool_cls = tools["create_calendar"].CreateCalendarEventTool
+    tool = tool_cls(user_id=1, user_timezone_str="UTC")
+    result = asyncio.run(tool._arun("meeting tomorrow"))
+    assert result.endswith("Should I add this to your calendar?")
+
+
+def test_delete_calendar_event(tools):
+    tool_cls = tools["delete_calendar"].DeleteCalendarEventTool
+    tool = tool_cls(user_id=1, user_timezone_str="UTC")
+    result = asyncio.run(tool._arun("abcde"))
+    assert result.startswith("Found event")
+
+
+def test_read_calendar_events(tools):
+    tool_cls = tools["read_calendar"].ReadCalendarEventsTool
+    tool = tool_cls(user_id=1, user_timezone_str="UTC")
+    result = asyncio.run(tool._arun("today"))
+    assert result == "formatted events"
+
+
+def test_search_calendar_events(tools):
+    tool_cls = tools["search_calendar"].SearchCalendarEventsTool
+    tool = tool_cls(user_id=1, user_timezone_str="UTC")
+    result = asyncio.run(tool._arun("meeting"))
+    assert result == "formatted events"


### PR DESCRIPTION
## Summary
- add `/menu` command using a reply keyboard to list common actions
- register the new command in the bot
- document `/menu` usage in README
- test the new `menu_command`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f75b64638832c86508d1fca5b1bbb