### PR TITLE
Add image processing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This project is a Telegram bot that uses a Large Language Model (LLM) agent to h
 ## Features
 
 - **Natural Language Understanding:** Interact with your calendar by typing commands in plain English (e.g., "Schedule a meeting for tomorrow at 2pm," "What's on my agenda for Friday?").
+- **Image Understanding:** Attach a screenshot or photo with your request and the bot will extract text from the image to help process your command.
 - **Google Calendar Integration:** Securely connects to your Google Calendar to manage events.
 - **Event Management:**
     - Create new calendar events.

--- a/handlers/chat.py
+++ b/handlers/chat.py
@@ -21,6 +21,16 @@ async def _handle_general_chat(update: Update, context: ContextTypes.DEFAULT_TYP
     user_id = update.effective_user.id
     logger.info(f"Handling GENERAL_CHAT for user {user_id} with history")
 
+    if update.message and update.message.photo:
+        try:
+            file = await update.message.photo[-1].get_file()
+            image_bytes = await file.download_as_bytearray()
+            img_text = await llm_service.extract_text_from_image(bytes(image_bytes))
+            if img_text:
+                text = f"{text}\n{img_text}" if text else img_text
+        except Exception as e:
+            logger.error(f"Error processing photo for general chat: {e}")
+
     history = await gs.get_chat_history(user_id, "general")
     logger.debug(f"General Chat: Loaded {len(history)} messages from Firestore for user {user_id}")
 
@@ -40,11 +50,22 @@ async def _handle_general_chat(update: Update, context: ContextTypes.DEFAULT_TYP
 
 
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    if not update.message or not update.message.text:
-        logger.warning("handle_message received update without message text.")
+    if not update.message or (not update.message.text and not update.message.photo):
+        logger.warning("handle_message received update without text or photo.")
         return
     user_id = update.effective_user.id
-    text = update.message.text
+    text = update.message.text or ""
+
+    if update.message.photo:
+        try:
+            file = await update.message.photo[-1].get_file()
+            image_bytes = await file.download_as_bytearray()
+            img_text = await llm_service.extract_text_from_image(bytes(image_bytes))
+            if img_text:
+                text = f"{text}\n{img_text}" if text else img_text
+        except Exception as e:
+            logger.error(f"Error processing photo for agent message: {e}")
+
     logger.info(f"Agent Handler: Received message from user {user_id}: '{text[:50]}...'")
 
     if not await gs.is_user_connected(user_id):

--- a/llm/llm_service.py
+++ b/llm/llm_service.py
@@ -41,6 +41,38 @@ else:
 
 # === LLM Interaction Functions ===
 
+async def extract_text_from_image(image_bytes: bytes) -> str | None:
+    """Extract text or a short description from an image."""
+    if not llm_available or not gemini_model:
+        logger.error("LLM Service (Image): LLM not available.")
+        return None
+
+    prompt = "Describe any text or important details in this image."
+    try:
+        response = await gemini_model.generate_content_async([
+            {"inline_data": {"mime_type": "image/jpeg", "data": image_bytes}},
+            {"text": prompt},
+        ])
+
+        if getattr(response, "prompt_feedback", None) and getattr(response.prompt_feedback, "block_reason", None):
+            logger.warning(f"LLM image description blocked: {response.prompt_feedback.block_reason}")
+            return None
+
+        if hasattr(response, "text"):
+            return response.text
+        if hasattr(response, "parts") and response.parts:
+            return "".join(part.text for part in response.parts if hasattr(part, "text"))
+        logger.warning("LLM image description response missing text content.")
+        return None
+
+    except GoogleAPIError as api_err:
+        logger.error(f"LLM Service (Image): Google API Error - {api_err}")
+        return None
+    except Exception as e:
+        logger.error(f"LLM Service (Image): Unexpected error - {e}", exc_info=True)
+        return None
+
+
 async def get_chat_response(history: list[dict]) -> str | None:
     """
     Gets a general chat response from the LLM, considering conversation history.


### PR DESCRIPTION
## Summary
- allow bot to extract text from images with `extract_text_from_image`
- include photo text in chat handling
- document that screenshots or photos can be used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841bafd6d38832cb6cd73229d135bed