### PR TITLE
Add image processing tests and caption support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This project is a Telegram bot that uses a Large Language Model (LLM) agent to h
 ## Features
 
 - **Natural Language Understanding:** Interact with your calendar by typing commands in plain English (e.g., "Schedule a meeting for tomorrow at 2pm," "What's on my agenda for Friday?").
+- **Image Understanding:** Attach a screenshot or photo with your request and the bot will extract text from the image to help process your command.
 - **Google Calendar Integration:** Securely connects to your Google Calendar to manage events.
 - **Event Management:**
     - Create new calendar events.

--- a/llm/llm_service.py
+++ b/llm/llm_service.py
@@ -41,6 +41,38 @@ else:
 
 # === LLM Interaction Functions ===
 
+async def extract_text_from_image(image_bytes: bytes) -> str | None:
+    """Extract text or a short description from an image."""
+    if not llm_available or not gemini_model:
+        logger.error("LLM Service (Image): LLM not available.")
+        return None
+
+    prompt = "Describe any text or important details in this image."
+    try:
+        response = await gemini_model.generate_content_async([
+            {"inline_data": {"mime_type": "image/jpeg", "data": image_bytes}},
+            {"text": prompt},
+        ])
+
+        if getattr(response, "prompt_feedback", None) and getattr(response.prompt_feedback, "block_reason", None):
+            logger.warning(f"LLM image description blocked: {response.prompt_feedback.block_reason}")
+            return None
+
+        if hasattr(response, "text"):
+            return response.text
+        if hasattr(response, "parts") and response.parts:
+            return "".join(part.text for part in response.parts if hasattr(part, "text"))
+        logger.warning("LLM image description response missing text content.")
+        return None
+
+    except GoogleAPIError as api_err:
+        logger.error(f"LLM Service (Image): Google API Error - {api_err}")
+        return None
+    except Exception as e:
+        logger.error(f"LLM Service (Image): Unexpected error - {e}", exc_info=True)
+        return None
+
+
 async def get_chat_response(history: list[dict]) -> str | None:
     """
     Gets a general chat response from the LLM, considering conversation history.

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -204,3 +204,50 @@ def test_menu_command_shows_keyboard(handlers_module):
     asyncio.run(handlers_module.menu_command(mock_update, mock_context))
 
     mock_message.reply_text.assert_called_once()
+
+
+def test_handle_message_photo_caption(monkeypatch, handlers_module):
+    # patch google services
+    monkeypatch.setattr(handlers_module.gs, "is_user_connected", AsyncMock(return_value=True), raising=False)
+    monkeypatch.setattr(handlers_module.gs, "get_user_timezone_str", AsyncMock(return_value="UTC"), raising=False)
+    monkeypatch.setattr(handlers_module.gs, "get_chat_history", AsyncMock(return_value=[]), raising=False)
+    monkeypatch.setattr(handlers_module.gs, "add_chat_message", AsyncMock(), raising=False)
+    monkeypatch.setattr(handlers_module, "get_pending_event", AsyncMock(return_value=None), raising=False)
+    monkeypatch.setattr(handlers_module, "delete_pending_event", AsyncMock(), raising=False)
+    monkeypatch.setattr(handlers_module, "get_pending_deletion", AsyncMock(return_value=None), raising=False)
+    monkeypatch.setattr(handlers_module, "delete_pending_deletion", AsyncMock(), raising=False)
+    monkeypatch.setattr(handlers_module.gs, "get_calendar_event_by_id", AsyncMock(return_value=None), raising=False)
+
+    # patch LLM service and agent
+    extract_mock = AsyncMock(return_value="image text")
+    monkeypatch.setattr(handlers_module.chat.llm_service, "extract_text_from_image", extract_mock, raising=False)
+
+    called = {}
+    class DummyExecutor:
+        async def ainvoke(self, data):
+            called["input"] = data
+            return {"output": "agent reply"}
+
+    monkeypatch.setattr(handlers_module.chat, "initialize_agent", lambda *a, **k: DummyExecutor())
+
+    # build update with photo and caption
+    dummy_file = types.SimpleNamespace(download_as_bytearray=AsyncMock(return_value=b"img"))
+    dummy_photo = types.SimpleNamespace(get_file=AsyncMock(return_value=dummy_file))
+    message = MagicMock()
+    message.text = None
+    message.caption = "caption"
+    message.photo = [dummy_photo]
+    message.chat = types.SimpleNamespace(send_action=AsyncMock())
+    message.reply_text = AsyncMock()
+
+    update = MagicMock()
+    update.message = message
+    update.effective_user.id = 1
+
+    context = MagicMock()
+
+    asyncio.run(handlers_module.handle_message(update, context))
+
+    extract_mock.assert_awaited_once()
+    assert called["input"] == {"input": "caption\nimage text"}
+    message.reply_text.assert_called_once()

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -1,0 +1,50 @@
+import importlib
+import types
+import asyncio
+import sys
+from unittest.mock import AsyncMock
+
+
+def setup_llm(monkeypatch, response):
+    sys.modules.pop("llm", None)
+    sys.modules.pop("llm.llm_service", None)
+    # stub packages required during import
+    google_mod = types.ModuleType("google")
+    genai_mod = types.ModuleType("google.generativeai")
+    api_core_mod = types.ModuleType("google.api_core")
+    exceptions_mod = types.ModuleType("google.api_core.exceptions")
+    exceptions_mod.GoogleAPIError = type("GoogleAPIError", (Exception,), {})
+    monkeypatch.setitem(sys.modules, "google", google_mod)
+    monkeypatch.setitem(sys.modules, "google.generativeai", genai_mod)
+    monkeypatch.setitem(sys.modules, "google.api_core", api_core_mod)
+    monkeypatch.setitem(sys.modules, "google.api_core.exceptions", exceptions_mod)
+    dateutil_pkg = types.ModuleType("dateutil")
+    parser_mod = types.ModuleType("dateutil.parser")
+    parser_mod.parse = lambda s: None
+    monkeypatch.setitem(sys.modules, "dateutil", dateutil_pkg)
+    monkeypatch.setitem(sys.modules, "dateutil.parser", parser_mod)
+    config_mod = types.ModuleType("config")
+    config_mod.GOOGLE_API_KEY = ""
+    monkeypatch.setitem(sys.modules, "config", config_mod)
+
+    llm = importlib.import_module("llm.llm_service")
+    gem_model = types.SimpleNamespace(generate_content_async=AsyncMock(return_value=response))
+    monkeypatch.setattr(llm, "gemini_model", gem_model)
+    monkeypatch.setattr(llm, "llm_available", True)
+    return llm, gem_model
+
+
+def test_extract_text_from_image_returns_text(monkeypatch):
+    response = types.SimpleNamespace(text="hello", prompt_feedback=None)
+    llm, model = setup_llm(monkeypatch, response)
+    result = asyncio.run(llm.extract_text_from_image(b"img"))
+    assert result == "hello"
+    model.generate_content_async.assert_awaited_once()
+
+
+def test_extract_text_from_image_blocked(monkeypatch):
+    feedback = types.SimpleNamespace(block_reason="safe")
+    response = types.SimpleNamespace(text="ignored", prompt_feedback=feedback)
+    llm, _ = setup_llm(monkeypatch, response)
+    result = asyncio.run(llm.extract_text_from_image(b"img"))
+    assert result is None


### PR DESCRIPTION
## Summary
- handle photo captions when processing user messages
- add unit tests for new caption flow in handlers
- add unit tests for image text extraction logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841bafd6d38832cb6cd73229d135bed