### PR TITLE
Improve deletion confirmation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This project is a Telegram bot that uses a Large Language Model (LLM) agent to h
 - **Event Management:**
     - Create new calendar events.
     - Delete existing calendar events.
+    - Delete events by natural language query (searches and asks for confirmation).
+    - Search for events by keyword and display their IDs for easy deletion.
     - View your agenda for specific days, weeks, or periods.
 - **Timezone Support:** Allows users to set their local timezone for accurate event scheduling and display.
 - **Conversation History:** Remembers the context of your conversation for a more natural interaction flow.

--- a/handler/message_formatter.py
+++ b/handler/message_formatter.py
@@ -29,3 +29,28 @@ async def create_final_message(pending_event_data):
         f"<b>Location:</b>    {display_location}\n\n"
         f"Ready to add this to your Google Calendar?"
     )
+
+
+async def create_delete_confirmation_message(event_details: dict) -> str:
+    """Format a confirmation message for deleting an event."""
+
+    summary = event_details.get("summary", "N/A")
+    start_info = event_details.get("start", {})
+    end_info = event_details.get("end", {})
+
+    start_iso = start_info.get("dateTime") or start_info.get("date", "")
+    end_iso = end_info.get("dateTime") or end_info.get("date", "")
+
+    description_text = event_details.get("description", "") or "Not specified"
+    location_text = event_details.get("location", "") or "Not specified"
+
+    return (
+        f"I found this event:\n\n"
+        f"✨ <b>{html.escape(summary)}</b> ✨\n\n"
+        f"📅 <b><u>Event Details</u></b>\n"
+        f"<b>Start:</b>       <code>{format_to_nice_date(start_iso)}</code>\n"
+        f"<b>End:</b>         <code>{format_to_nice_date(end_iso)}</code>\n"
+        f"<b>Description:</b> <i>{html.escape(description_text)}</i>\n"
+        f"<b>Location:</b>    <i>{html.escape(location_text)}</i>\n\n"
+        "Should I delete this event?"
+    )

--- a/llm/agent_tools.py
+++ b/llm/agent_tools.py
@@ -5,6 +5,7 @@ from langchain.tools import BaseTool  # Use BaseTool for async/context
 
 from llm.tools.create_calendar import CreateCalendarEventTool
 from llm.tools.delete_calendar import DeleteCalendarEventTool
+from llm.tools.delete_by_query import DeleteCalendarEventByQueryTool
 from llm.tools.get_current_time_tool import GetCurrentTimeTool
 from llm.tools.read_calendar import ReadCalendarEventsTool
 from llm.tools.search_calendar import SearchCalendarEventsTool
@@ -22,6 +23,7 @@ def get_tools(user_id: int, user_timezone_str: str) -> list[BaseTool]:
         SearchCalendarEventsTool(user_id=user_id, user_timezone_str=user_timezone_str),
         CreateCalendarEventTool(user_id=user_id, user_timezone_str=user_timezone_str),
         DeleteCalendarEventTool(user_id=user_id, user_timezone_str=user_timezone_str),
+        DeleteCalendarEventByQueryTool(user_id=user_id, user_timezone_str=user_timezone_str),
         GetCurrentTimeTool(user_id=user_id, user_timezone_str=user_timezone_str),
         AddGroceryItemTool(user_id=user_id, user_timezone_str=user_timezone_str),
         ShowGroceryListTool(user_id=user_id, user_timezone_str=user_timezone_str),

--- a/llm/tools/delete_by_query.py
+++ b/llm/tools/delete_by_query.py
@@ -1,0 +1,78 @@
+import logging
+from datetime import datetime
+
+import pytz
+from pytz.exceptions import UnknownTimeZoneError
+
+import google_services as gs
+from llm import llm_service
+from llm.tools.calendar_base import CalendarBaseTool
+from llm.tools.delete_calendar import DeleteCalendarEventTool
+from llm.tools.formatting import format_event_list_for_agent
+
+logger = logging.getLogger(__name__)
+
+
+class DeleteCalendarEventByQueryTool(CalendarBaseTool):
+    """Searches for an event using a natural language query and prepares it for deletion."""
+
+    name: str = "delete_calendar_event_by_query"
+    description: str = (
+        "Input is a natural language description of the event to delete. "
+        "Searches for matching events and, if exactly one match is found, "
+        "asks the user for confirmation to delete it. If multiple matches are "
+        "found, returns the list with event IDs."
+    )
+
+    async def _arun(self, search_query: str) -> str:
+        logger.info(
+            f"Tool: DeleteCalendarEventByQuery: User={self.user_id}, Query='{search_query}'"
+        )
+        if not self.user_id:
+            return "Error: User context missing."
+        if not search_query:
+            return "Error: Search query cannot be empty."
+
+        try:
+            user_tz = pytz.timezone(self.user_timezone_str)
+        except UnknownTimeZoneError:
+            user_tz = pytz.utc
+        now_local_iso = datetime.now(user_tz).isoformat()
+
+        parsed_args = await llm_service.extract_search_args_llm(search_query, now_local_iso)
+        if not parsed_args:
+            return f"Error: Could not understand search query '{search_query}'."
+
+        query = parsed_args["query"]
+        start_iso = parsed_args["start_iso"]
+        end_iso = parsed_args["end_iso"]
+
+        events = await gs.search_calendar_events(
+            self.user_id,
+            query=query,
+            time_min_iso=start_iso,
+            time_max_iso=end_iso,
+            max_results=5,
+        )
+        if events is None:
+            return "Error: Could not search calendar events."
+        if not events:
+            return f"No events found matching '{query}'."
+
+        if len(events) > 1:
+            formatted = format_event_list_for_agent(
+                events, f"matching '{query}'", self.user_timezone_str, include_ids=True
+            )
+            return (
+                "Multiple events found. Please specify the ID of the event to delete:\n\n"
+                + formatted
+            )
+
+        event_id = events[0].get("id")
+        if not event_id:
+            return "Error: Event ID missing."
+
+        del_tool = DeleteCalendarEventTool(
+            user_id=self.user_id, user_timezone_str=self.user_timezone_str
+        )
+        return await del_tool._arun(event_id)

--- a/llm/tools/formatting.py
+++ b/llm/tools/formatting.py
@@ -138,11 +138,14 @@ def format_event_list_for_agent(events: list, time_period_str: str, user_timezon
         # Event Item
         output_lines.append(f"  ✨ <b>{summary}</b>")  # Intend with spaces
         if parsed_time_str:
-            time_line = f"⏰ <i>{html.escape(parsed_time_str)}"  # Use <pre> for indent
+            time_line = f"⏰ <i>{html.escape(parsed_time_str)}"
             if parsed_duration_str and not time_info.get('is_all_day'):
                 time_line += f" {html.escape(parsed_duration_str)}"
             time_line += "</i>"
             output_lines.append(time_line)
+
+        if include_ids and event_id:
+            output_lines.append(f"🆔 <code>{html.escape(event_id)}</code>")
 
         if location:
             encoded_location = urllib.parse.quote_plus(location)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -112,7 +112,10 @@ def handlers_module(monkeypatch):
     sys.modules["utils"] = utils_mod
     # stub handler.message_formatter
     msg_mod = types.ModuleType("handler.message_formatter")
-    msg_mod.create_final_message = lambda data: ""
+    async def dummy_create(data=None):
+        return ""
+    msg_mod.create_final_message = dummy_create
+    msg_mod.create_delete_confirmation_message = dummy_create
     sys.modules["handler.message_formatter"] = msg_mod
     handlers = importlib.import_module("handlers")
     return handlers


### PR DESCRIPTION
## Summary
- show detailed info when confirming event deletion
- reuse new formatter in chat handler
- test helper modules patched with async delete confirmation function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844426923a0832c9fd213a3a3a5e7ef