### PR TITLE
Fix agent final answer with formatted events

### DIFF
--- a/llm/agent.py
+++ b/llm/agent.py
@@ -53,10 +53,12 @@ def initialize_agent(user_id: int, user_timezone_str: str, chat_history: list) -
     Thought: Step-by-step thinking process. If deleting, first use 'search_calendar_events' to find the event ID. Then, use 'delete_calendar_event' with ONLY the event ID. If creating, use 'create_calendar_event' with the natural language description.
     Action: the action to take, one of [{", ".join([t.name for t in tools])}]
     Action Input: The required input for the action (natural language for create/read/search, event ID for delete).
-    Observation: the result of the action. **IMPORTANT: If the Observation from 'create_calendar_event' or 'delete_calendar_event' is a question asking for confirmation (e.g., "Should I add this..." or "Should I delete this..."), your job is done for this step. Your Final Answer MUST be exactly that confirmation question.** Do not try to call the tool again or re-answer the original question in this case.
+    Observation: the result of the action.
+    **IMPORTANT:** If the Observation from 'create_calendar_event' or 'delete_calendar_event' is a question asking for confirmation (e.g., "Should I add this..." or "Should I delete this..."), your job is done for this step. Your Final Answer MUST be exactly that confirmation question. Do not try to call the tool again or re-answer the original question in this case.
+    If the Observation is a formatted list of calendar events (e.g., from 'read_calendar_events' or 'search_calendar_events'), your Final Answer MUST be exactly that formatted list with no changes.
     ... (this Thought/Action/Action Input/Observation can repeat N times)
     Thought: I have the information needed OR the tool returned a confirmation question.
-    Final Answer: the final answer to the original input question, OR the exact confirmation question returned by the create/delete tool.
+    Final Answer: the final answer to the original input question, OR the exact confirmation question returned by a tool.
 
     Begin!
 


### PR DESCRIPTION
## Summary
- improve ReAct prompt so final answers with calendar events reuse the HTML formatted list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68459c3c5ec0832c8e079c8eeb057c1f