### PR TITLE
Enable multiple event creation

### DIFF
--- a/handler/message_formatter.py
+++ b/handler/message_formatter.py
@@ -4,24 +4,48 @@ from time_util import format_to_nice_date
 
 
 async def create_final_message(pending_event_data):
-    summary = pending_event_data.get('summary', 'N/A')
-    # Re-parse and format start/end times for confirmation display
-    # This assumes start/end in pending_event_data are like {'dateTime': ISO, 'timeZone': IANA}
-    start_dt_iso = pending_event_data.get('start', {})
-    end_dt_iso = pending_event_data.get('end', {})
-    if not start_dt_iso: raise ValueError("Missing start dateTime in pending event")
-    # Construct the detailed confirmation message HERE
-    start_date_time = start_dt_iso.get('dateTime', '')
-    end_date_time = end_dt_iso.get('dateTime', '')
+    """Format a pending event or list of events for user confirmation."""
+    if isinstance(pending_event_data, list):
+        lines = ["Okay, I can create these events:\n"]
+        for idx, ev in enumerate(pending_event_data, 1):
+            summary = html.escape(ev.get("summary", "N/A"))
+            start_dt_iso = ev.get("start", {})
+            end_dt_iso = ev.get("end", {})
+            if not start_dt_iso:
+                raise ValueError("Missing start dateTime in pending event")
+            start_date_time = start_dt_iso.get("dateTime", "")
+            end_date_time = end_dt_iso.get("dateTime", "")
+            description_text = ev.get("description", "-") or "-"
+            location_text = ev.get("location", "-") or "-"
+            lines.extend(
+                [
+                    f"{idx}. <b>{summary}</b>",
+                    f"   <i>{format_to_nice_date(start_date_time)} - {format_to_nice_date(end_date_time)}</i>",
+                    f"   Desc: {html.escape(description_text)}",
+                    f"   Loc: {html.escape(location_text)}",
+                    "",
+                ]
+            )
+        lines.append("Ready to add these to your Google Calendar?")
+        return "\n".join(lines)
+
+    summary = pending_event_data.get("summary", "N/A")
+    start_dt_iso = pending_event_data.get("start", {})
+    end_dt_iso = pending_event_data.get("end", {})
+    if not start_dt_iso:
+        raise ValueError("Missing start dateTime in pending event")
+
+    start_date_time = start_dt_iso.get("dateTime", "")
+    end_date_time = end_dt_iso.get("dateTime", "")
     escaped_summary = html.escape(summary)
-    description_text = pending_event_data.get('description', '-')
-    location_text = pending_event_data.get('location', '-')
+    description_text = pending_event_data.get("description", "-")
+    location_text = pending_event_data.get("location", "-")
     display_description = f"<i>{description_text if description_text else 'Not specified'}</i>"
     display_location = f"<i>{location_text if location_text else 'Not specified'}</i>"
 
     return (
         f"Okay, I can create this event for you:\n\n"
-        f"✨ <b>{escaped_summary}</b> ✨\n\n"  # Emphasized Summary/Title
+        f"✨ <b>{escaped_summary}</b> ✨\n\n"
         f"📅 <b><u>Event Details</u></b>\n"
         f"<b>Start:</b>       <code>{format_to_nice_date(start_date_time)}</code>\n"
         f"<b>End:</b>         <code>{format_to_nice_date(end_date_time)}</code>\n"

--- a/oauth_server.py
+++ b/oauth_server.py
@@ -124,6 +124,3 @@ if __name__ == '__main__':
         logger.info(f"Starting OAuth callback server on {config.WEB_SERVER_HOST}:{config.WEB_SERVER_PORT}")
         # Use waitress or gunicorn for production instead of Flask's dev server
         app.run(host=config.WEB_SERVER_HOST, port=config.WEB_SERVER_PORT, debug=False)
-
-
-281276958363-eq20la3m4cv7r8hssv75555u5n2v3mv0.apps.googleusercontent.com

--- a/tests/test_google_services_integration.py
+++ b/tests/test_google_services_integration.py
@@ -202,6 +202,17 @@ def test_pending_event_flow(gs_module):
     assert asyncio.run(gs.get_pending_event(user_id)) is None
 
 
+def test_pending_event_flow_multiple(gs_module):
+    gs = gs_module
+    user_id = 2
+    events = [{"id": "a"}, {"id": "b"}]
+    assert asyncio.run(gs.add_pending_event(user_id, events))
+    fetched = asyncio.run(gs.get_pending_event(user_id))
+    assert fetched == events
+    assert asyncio.run(gs.delete_pending_event(user_id))
+    assert asyncio.run(gs.get_pending_event(user_id)) is None
+
+
 def test_pending_deletion_flow(gs_module):
     gs = gs_module
     user_id = 1


### PR DESCRIPTION
## Summary
- parse multi-event requests in the LLM service
- show multiple events in confirmation messages
- store multiple pending events and create all on confirmation
- add tests for multi-event creation and pending-event lists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e4efa388832c8b2afcdac9eb03f1